### PR TITLE
port Validation tests from Haskell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalaVersion := "2.9.2"
 
 scalaSource in Compile <<= baseDirectory(_ / "src")
 
+scalaSource in Test <<= baseDirectory(_ / "test" / "src")
+
 libraryDependencies ++= Seq( 
   "org.scalatest" %% "scalatest" % "1.6.1" % "test",
   "org.scalaz" % "scalaz-core_2.9.2" % "7.0.0-M3",

--- a/test/src/L01/Validation/Tests.scala
+++ b/test/src/L01/Validation/Tests.scala
@@ -1,0 +1,37 @@
+package L01
+
+import org.scalatest.FeatureSpec
+import org.scalatest.prop.Checkers
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.oneOf
+
+import scalaz._
+import Scalaz._
+
+class ValidationTests extends FeatureSpec with Checkers {
+
+  implicit def arbitraryValidationInt(implicit a: Arbitrary[Int]): Arbitrary[Validation[Int]] =
+    Arbitrary(oneOf(arbitrary[Int] map (x => Value(x)),
+                    arbitrary[Int] map (x => Error(x.toString))))
+
+  feature("Validation") {
+    scenario("isError is not equal to isValue") (check(prop_isError_isValue))
+    scenario("valueOr produces or isValue") (check(prop_valueOr))
+    scenario("errorOr produces or isError") (check(prop_errorOr))
+    scenario("map maps") (check(prop_map))
+  }
+
+  val prop_isError_isValue: Validation[Int] => Boolean =
+    x => x.isError /== x.isValue
+
+  val prop_valueOr: (Validation[Int], Int) => Boolean =
+    (x, n) => x.isValue || x.valueOr(n) == n
+
+  val prop_errorOr: (Validation[Int], String) => Boolean =
+    (x, e) => x.isError || x.errorOr(e) == e
+
+  val prop_map: (Validation[Int], Int => Int, Int) => Boolean =
+    (x, f, n) => f(x.valueOr(n)) == x.map(f).valueOr(f(n))
+
+}


### PR DESCRIPTION
- add test/src to sbt test sources
- convert Validation/Tests.hs tests to Validation/Tests.scala
  - uses `FeatureSpec` for its similar structure to test-framework
