### PR TITLE
Make sure jsonNumber is a token parser

### DIFF
--- a/src/Course/JsonParser.hs
+++ b/src/Course/JsonParser.hs
@@ -162,7 +162,7 @@ jsonNumber ::
 jsonNumber =
   P (\i -> case readFloats i of
              Empty -> ErrorResult Failed
-             Full (n, z) -> Result z n)
+             Full (n, z) -> Result z n) <* spaces
 
 -- | Parse a JSON true literal.
 --


### PR DESCRIPTION
Skip trailing spaces in `jsonNumber`. Alternatively, `jsonValue` could skip trailing spaces, but this is more consistent with the behavior of `jsonString`.

Without this change, `parse jsonArray "[ 1 ]"` resulted in a ParseError.

New test can be found in NICTA/course#112.