### PR TITLE
Change Applicative implementation of OptionalT

### DIFF
--- a/src/Course/StateT.hs
+++ b/src/Course/StateT.hs
@@ -217,8 +217,10 @@ instance Functor f => Functor (OptionalT f) where
 instance Applicative f => Applicative (OptionalT f) where
   pure =
     OptionalT . pure . pure
-  OptionalT f <*> OptionalT a =
-    OptionalT (lift2 (<*>) f a)
+
+  OptionalT g <*> mx = OptionalT $ g >>= (\ o -> case o of
+                                                   Empty -> pure Empty
+                                                   Full f -> runOptionalT (f <$> mx))
 
 -- | Implement the `Monad` instance for `OptionalT f` given a Monad f.
 --


### PR DESCRIPTION
It seems `<*>` implementation of `OptionalT` is incorrectly

The correct output should be 
```
-- >>> runOptionalT $ OptionalT (Full (+1) :. Empty :. Nil) <*> OptionalT (Full 1 :. Full 2 :. Nil)
-- [Full 2,Full 3,Empty]
```  
https://github.com/data61/fp-course/blob/master/src/Course/StateT.hs#L238

I checked `MaybeT` in `transformers`, that should be the correct result. 

But current result is

` [Full 2,Full 3,Empty,Empty]`